### PR TITLE
Django upgrade 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo organizes the backend of a Conference Management System for Model UN c
 
 ## Development Instructions
 
-At the moment this project uses Python 3.8+ and Django 3.2.25. It is recommended to create a virtual environment inside the `envs` folder, e.g. by using [venv](https://docs.python.org/3/tutorial/venv.html).
+At the moment this project uses Python 3.8+ and Django 4.2.15 (LTS). It is recommended to create a virtual environment inside the `envs` folder, e.g. by using [venv](https://docs.python.org/3/tutorial/venv.html).
 
 To install the requirements after cloning the code and activating the environment (e.g. `source envs/my-env/bin/activate`), run
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -2,10 +2,14 @@ from django.contrib import admin
 from .models import Conference, Participant, Delegate, StudentOfficer, MUNDirector, Executive, Staff, Advisor, MemberOrganization, School, Forum, Plenary, Location, Room, Event, Lunch, Issue, Document, ResearchReport, PositionPaper
 from django.utils.safestring import mark_safe
 
+@admin.register(Advisor, Delegate, Executive, MUNDirector, Participant, Staff, StudentOfficer)
 class ParticipantAdmin(admin.ModelAdmin):
     readonly_fields = ('rendered_badge_photo',)
     
     # Display the rendered badge photo in the admin site
+    @admin.display(
+        description='Rendered Badge Photo'
+    )
     def rendered_badge_photo(self, obj):
         if obj.picture:
             if obj.picture.startswith('data:image/') and ';base64,' in obj.picture:
@@ -15,19 +19,11 @@ class ParticipantAdmin(admin.ModelAdmin):
         else:
             return 'No Photo Available'
     
-    rendered_badge_photo.short_description = 'Rendered Badge Photo'
 
 
 # Register your models here for the admin site.
 
 admin.site.register(Conference)
-admin.site.register(Participant, ParticipantAdmin)
-admin.site.register(Delegate, ParticipantAdmin)
-admin.site.register(StudentOfficer, ParticipantAdmin)
-admin.site.register(MUNDirector, ParticipantAdmin)
-admin.site.register(Executive, ParticipantAdmin)
-admin.site.register(Staff, ParticipantAdmin)
-admin.site.register(Advisor, ParticipantAdmin)
 admin.site.register(MemberOrganization)
 admin.site.register(School)
 admin.site.register(Forum)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,4 +1,3 @@
-from django.conf.urls import url
 from rest_framework.routers import DefaultRouter
 
 from api.views import ConferenceViewSet, SchoolViewSet, MemberOrganizationViewSet, LocationViewSet, RoomViewSet, EventViewSet, LunchViewSet, PlenaryViewSet, ForumViewSet, ParticipantViewSet, DelegateViewSet, StudentOfficerViewSet, MUNDirectorViewSet, ExecutiveViewSet, StaffViewSet, AdvisorViewSet, IssueViewSet, DocumentViewSet, ResearchReportViewSet, PositionPaperViewSet

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -118,7 +118,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -158,6 +158,9 @@ CORS_ORIGIN_ALLOW_ALL = False
 CORS_ORIGIN_WHITELIST = [
         'http://localhost:8080',
 ]
+CSRF_TRUSTED_ORIGINS = [
+        'http://localhost:8080',
+]
 
 # since Django 3.2, the default primary key needs to be set explicitly to keep AutoField instead of enw BigAutoField
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -14,8 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
-from django.conf.urls import url, include
+from django.urls import include, path, re_path
 from django.conf import settings
 from django.conf.urls.static import static
 from rest_framework.authtoken import views
@@ -23,9 +22,9 @@ from rest_framework.authtoken import views
 urlpatterns = [
     path('admin/doc/', include('django.contrib.admindocs.urls')),
     path('admin/', admin.site.urls),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-    url(r'^api/', include('api.urls', namespace='api')),
-    url(r'^api-token-auth/', views.obtain_auth_token),
-    url(r'^pdfs/', include('pdfs.urls', namespace='pdfs')),
-    url(r'^stats/', include('stats.urls', namespace='stats'))
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    path('api/', include('api.urls', namespace='api')),
+    re_path(r'^api-token-auth/', views.obtain_auth_token),
+    path('pdfs/', include('pdfs.urls', namespace='pdfs')),
+    path('stats/', include('stats.urls', namespace='stats'))
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ asgiref==3.8.1
 Babel==2.9.1
 certifi==2024.7.4
 distlib==0.3.0
-Django==3.2.25
-django-cors-headers==3.2.1
-django-extensions==2.2.5
+Django==4.2.15
+django-cors-headers==4.4.0
+django-extensions==3.2.3
 django-filter==2.4.0
-django-phonenumber-field==3.0.1
-django-multiselectfield==0.1.12
+django-phonenumber-field==7.3.0
+django-multiselectfield==0.1.13
 djangorestframework==3.15.2
 docutils==0.15.2
 Faker==13.12.1


### PR DESCRIPTION
Switched to long term support version 4.2 of Django. Extended Support will end in 2026, so upgrading to 5.2 LTS in 2025 makes sense.

I've used django-upgrade to automatically adapt the code from the old Django version.

I've manually updated the versions of dependencies.