### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate_api_visualization.yml
+++ b/.github/workflows/generate_api_visualization.yml
@@ -1,4 +1,6 @@
 name: Generate API Visualization
+permissions:
+  contents: write
 # This workflow is triggered on pull request events on any branch, only when 'api/models.py' is modified. Or when a developer triggers it. It generates an API visualization file and pushes it to the repository, so that it can be viewed in the GitHub repository README.
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/model-united-nations-of-luebeck/CMS-backend/security/code-scanning/1](https://github.com/model-united-nations-of-luebeck/CMS-backend/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the least privilege required for the workflow to function. Since the workflow pushes a file to the repository, it needs `contents: write` permission. The best way to fix this is to add the following block at the top level of the workflow (just after the `name:` line and before the `on:` block):

```yaml
permissions:
  contents: write
```

This ensures that the workflow only has write access to repository contents and does not inherit broader permissions. No other permissions are required for the described steps. You do not need to change any other lines or add any imports.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
